### PR TITLE
Adding print to media for css style

### DIFF
--- a/results.html
+++ b/results.html
@@ -4,7 +4,8 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 	<title>PolitiScales - Résultats</title>
-	<link rel="stylesheet" href="style.css" type="text/css" media="screen" />
+	<link rel="stylesheet" href="style.css" type="text/css" 
+media="print, screen" />
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 	<script type="application/javascript" src="flags.js"></script>


### PR DESCRIPTION
Hey,

By adding the "print" keyword inside the media declaration of the css, it improves a little bit the print result.

See these examples :
**Without** :
![without](https://user-images.githubusercontent.com/6367611/30820824-663c87ae-a223-11e7-82d2-ed5742bb8292.png)

**With** :
![with](https://user-images.githubusercontent.com/6367611/30820747-24bab97c-a223-11e7-8959-02cb7a517573.png)

And this Stackoverflow answer : https://stackoverflow.com/a/14568568